### PR TITLE
Implement handleCardSetup()

### DIFF
--- a/projects/ngx-stripe/src/lib/interfaces/stripe.ts
+++ b/projects/ngx-stripe/src/lib/interfaces/stripe.ts
@@ -8,7 +8,8 @@ import {
   BankAccount,
   BankAccountData,
   Pii,
-  PiiData
+  PiiData,
+  SetupIntentData, SetupIntentResult,
 } from './token';
 import { SourceData, SourceResult, SourceParams } from './sources';
 
@@ -27,6 +28,7 @@ export interface StripeJS {
   createToken(pii: Pii, piiData: PiiData): Promise<TokenResult>;
   createSource(el: Element, sourceData?: SourceData): Promise<SourceResult>;
   createSource(sourceData: SourceData): Promise<SourceResult>;
+  handleCardSetup(clientSecret: string, el: Element, cardSetupOptions?: SetupIntentData): Promise<SetupIntentResult>;
   retrieveSource(source: SourceParams): Promise<SourceResult>;
 }
 

--- a/projects/ngx-stripe/src/lib/interfaces/token.ts
+++ b/projects/ngx-stripe/src/lib/interfaces/token.ts
@@ -113,3 +113,59 @@ export function isPii(pii: any): pii is Pii {
 export function isPiiData(piiData: any): piiData is PiiData {
   return 'personal_id_number' in piiData;
 }
+
+export interface SetupIntent {
+  id: string;
+  object: 'setup_intent';
+  application?: string;
+  cancellation_reason?: 'abandoned' | 'requested_by_customer' | 'duplicate';
+  client_secret?: string;
+  created: number;
+  customer?: string;
+  description?: string;
+  last_setup_error?: Error;
+  livemode: boolean;
+  metadata: { [key: string]: any };
+  next_action: {
+    type: 'redirect_to_url' | 'use_stripe_sdk';
+    redirect_to_url?: {
+      return_url: string;
+      url: string;
+    };
+    use_stripe_sdk:  { [key: string]: any };
+  };
+  on_behalf_of?: string;
+  payment_method?: string;
+  payment_method_options?: { [key: string]: any };
+  status:
+    'requires_payment_method' |
+    'requires_confirmation' |
+    'requires_action' |
+    'processing' |
+    'canceled' |
+    'succeeded';
+  usage: 'on_session' | 'off_session';
+}
+
+export interface SetupIntentResult {
+  setupIntent?: SetupIntent;
+  error?: Error;
+}
+
+export interface SetupIntentData {
+  payment_method_data?: {
+    billing_details?: {
+      address?: {
+        city?: string
+        country?: string
+        line1?: string
+        line2?: string
+        postal_code?: string
+        state?: string
+      }
+      email?: string
+      name?: string
+      phone?: string
+    };
+  };
+}

--- a/projects/ngx-stripe/src/lib/services/stripe.service.ts
+++ b/projects/ngx-stripe/src/lib/services/stripe.service.ts
@@ -5,7 +5,19 @@ import { Element } from '../interfaces/element';
 import { Elements, ElementsOptions } from '../interfaces/elements';
 import { isSourceData, SourceData, SourceParams, SourceResult } from '../interfaces/sources';
 import { Options, StripeJS, STRIPE_OPTIONS, STRIPE_PUBLISHABLE_KEY } from '../interfaces/stripe';
-import { BankAccount, BankAccountData, CardDataOptions, isBankAccount, isBankAccountData, isPii, isPiiData, Pii, PiiData, TokenResult } from '../interfaces/token';
+import {
+  BankAccount,
+  BankAccountData,
+  CardDataOptions,
+  isBankAccount,
+  isBankAccountData,
+  isPii,
+  isPiiData,
+  Pii,
+  PiiData, SetupIntentData,
+  SetupIntentResult,
+  TokenResult
+} from '../interfaces/token';
 import { LazyStripeAPILoader, Status } from './api-loader.service';
 import { PlatformService } from './platform.service';
 import { WindowRef } from './window-ref.service';
@@ -70,6 +82,16 @@ export class StripeService {
         this.stripe.createToken(a as Element, b as CardDataOptions | undefined)
       );
     }
+  }
+
+  public handleCardSetup(
+    clientSecret: string,
+    element: Element,
+    cardSetupOptions?: SetupIntentData | undefined
+  ): Observable<SetupIntentResult> {
+    return observableFrom(
+      this.stripe.handleCardSetup(clientSecret, element, cardSetupOptions)
+    );
   }
 
   public createSource(


### PR DESCRIPTION
Adds the [`handleCardSetup()`](https://stripe.com/docs/stripe-js/reference#stripe-handle-card-setup) function that's needed when you want to save a payment method without directly charging with the latest version of the Stripe API.

Need the function myself, but also closes https://github.com/nomadreservations/ngx-stripe/issues/8.