### PR TITLE
Implement create payment method

### DIFF
--- a/projects/ngx-stripe/src/lib/interfaces/payment-method.ts
+++ b/projects/ngx-stripe/src/lib/interfaces/payment-method.ts
@@ -1,0 +1,54 @@
+import { Error } from './utils';
+import { BillingDetails } from './token';
+import { Element } from './element';
+
+export interface PaymentMethodParams {
+  type: 'card' | 'ideal' | 'sepa_debit';
+  card: Element;
+  billing_details: BillingDetails;
+}
+
+export interface PaymentMethodResult {
+  error: Error;
+  paymentMethod: PaymentMethodData;
+}
+
+export interface PaymentMethodData {
+  id: string;
+  object: string;
+  billing_details: BillingDetails;
+  card: {
+    brand: 'amex' | 'discover' | 'jcb' | 'mastercard' | 'unionpay' | 'visa' | 'unknown';
+    checks: {
+        address_line1_check: string;
+        address_postal_code_check: string;
+        cvc_check: string;
+    }
+    country: string;
+    exp_month: number;
+    exp_year: number;
+    fingerprint: string;
+    funding: 'credit' | 'debit' | 'prepaid' | 'unknown';
+    generated_from: any;
+    last4: string;
+    three_d_secure_usage: {
+        supported: boolean;
+    }
+    wallet: any;
+  };
+  card_present: any;
+  customer: string;
+  ideal: {
+      bank: string;
+      bic: string;
+  };
+  livemode: boolean;
+  metadata: any;
+  sepa_debit: {
+      bank_code: string;
+      branch_code: string;
+      country: string;
+      fingerprint: string;
+      last4: string;
+  }
+}

--- a/projects/ngx-stripe/src/lib/interfaces/payment-method.ts
+++ b/projects/ngx-stripe/src/lib/interfaces/payment-method.ts
@@ -6,6 +6,13 @@ export interface PaymentMethodParams {
   type: 'card' | 'ideal' | 'sepa_debit';
   card: Element;
   billing_details: BillingDetails;
+  ideal?: {
+    bank?: string;
+  };
+  metadata?: { [key: string]: any };
+  sepa_debit?: {
+    iban: string
+  };
 }
 
 export interface PaymentMethodResult {
@@ -15,40 +22,45 @@ export interface PaymentMethodResult {
 
 export interface PaymentMethodData {
   id: string;
-  object: string;
+  object: 'payment_method';
   billing_details: BillingDetails;
   card: {
     brand: 'amex' | 'discover' | 'jcb' | 'mastercard' | 'unionpay' | 'visa' | 'unknown';
     checks: {
-        address_line1_check: string;
-        address_postal_code_check: string;
-        cvc_check: string;
-    }
+        address_line1_check: 'pass' | 'fail' | 'unavailable' | 'unchecked';
+        address_postal_code_check: 'pass' | 'fail' | 'unavailable' | 'unchecked';
+        cvc_check: 'pass' | 'fail' | 'unavailable' | 'unchecked';
+    };
     country: string;
     exp_month: number;
     exp_year: number;
     fingerprint: string;
     funding: 'credit' | 'debit' | 'prepaid' | 'unknown';
-    generated_from: any;
+    generated_from: {
+      charge: string;
+      payment_method_details: any;
+    };
     last4: string;
     three_d_secure_usage: {
         supported: boolean;
-    }
+    };
     wallet: any;
   };
   card_present: any;
+  created: number;
   customer: string;
   ideal: {
-      bank: string;
+      bank: 'abn_amro' | 'asn_bank' | 'bunq' | 'handelsbaknken' | 'ing' | 'knab' | 'moneyou' | 'rabobank' | 'regiobank' | 'sns_bank' | 'triodos_bank' | 'van_lanschot';
       bic: string;
   };
   livemode: boolean;
-  metadata: any;
+  metadata: { [key: string]: any };
   sepa_debit: {
       bank_code: string;
       branch_code: string;
       country: string;
       fingerprint: string;
       last4: string;
-  }
+  };
+  type: 'card' | 'ideal' | 'sepa_debit';
 }

--- a/projects/ngx-stripe/src/lib/interfaces/stripe.ts
+++ b/projects/ngx-stripe/src/lib/interfaces/stripe.ts
@@ -1,3 +1,4 @@
+import { PaymentMethodParams, PaymentMethodResult } from './payment-method';
 import { InjectionToken } from '@angular/core';
 import { Element, RequestElementOptions } from './element';
 import { Elements, ElementsOptions } from './elements';
@@ -35,6 +36,7 @@ export interface StripeJS {
   confirmSetupIntent(clientSecret: string, el: Element, data: ConfirmSetupIntentData);
   retrieveSetupIntent(clientSecret: string);
   retrieveSource(source: SourceParams): Promise<SourceResult>;
+  createPaymentMethod(paymentMethod: PaymentMethodParams): Promise<PaymentMethodResult>;
 }
 
 export interface Options {

--- a/projects/ngx-stripe/src/lib/services/stripe.service.ts
+++ b/projects/ngx-stripe/src/lib/services/stripe.service.ts
@@ -1,3 +1,5 @@
+import { PaymentMethodParams, PaymentMethodResult } from './../interfaces/payment-method';
+import { BillingDetails } from './../interfaces/token';
 declare var Stripe;
 
 import { Inject, Injectable } from '@angular/core';
@@ -141,5 +143,9 @@ export class StripeService {
 
   public retrieveSource(source: SourceParams): Observable<SourceResult> {
     return observableFrom(this.stripe.retrieveSource(source));
+  }
+
+  public createPaymentMethod(paymentMethod: PaymentMethodParams): Observable<PaymentMethodResult> {
+    return observableFrom(this.stripe.createPaymentMethod(paymentMethod));
   }
 }

--- a/projects/ngx-stripe/src/lib/services/stripe.service.ts
+++ b/projects/ngx-stripe/src/lib/services/stripe.service.ts
@@ -1,5 +1,4 @@
 import { PaymentMethodParams, PaymentMethodResult } from './../interfaces/payment-method';
-import { BillingDetails } from './../interfaces/token';
 declare var Stripe;
 
 import { Inject, Injectable } from '@angular/core';


### PR DESCRIPTION
This PR implements the [create payment method](https://stripe.com/docs/stripe-js/reference#stripe-create-payment-method) functionality. I have a requirement to create a payment method to add to a customer later. 