### PR TITLE
chore(core): update ngx-stripe module to angular 9

### DIFF
--- a/projects/ngx-stripe/src/lib/ngx-stripe.module.ts
+++ b/projects/ngx-stripe/src/lib/ngx-stripe.module.ts
@@ -20,7 +20,7 @@ export interface NgxStripeModuleOptions {
   exports: [StripeCardComponent, PaymentRequestComponent]
 })
 export class NgxStripeModule {
-  public static forRoot(publishableKey: string, options?: Options): ModuleWithProviders {
+  public static forRoot(publishableKey: string, options?: Options): ModuleWithProviders<NgxStripeModule> {
     return {
       ngModule: NgxStripeModule,
       providers: [


### PR DESCRIPTION
Just updated the moduleWithProviders type. Works fine here.

Updating the application is more tricky. We may have to stop using ng-packagr, because it mess with its typescript version. 